### PR TITLE
Make git ignore compiled translation files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ eggs
 parts
 rebuild_i18n.log
 var
+*.mo


### PR DESCRIPTION
Compiled translation files shouldn't be in repo right?
I'd like anyone's second opinion on this, @hvelarde maybe? 
