### PR TITLE
Fixing required field attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Changelog
 
 - Fixed demotypes registration on modern Plone (Default alias was not working)
   [keul]
+- Added a real support for Archetypes ``required`` attribute. This will probably deprecate
+  the need of the ``isDataGridFilled`` validator
+  [keul]
 
 1.9.1 (2014-10-14)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.9.2 (Unreleased)
+------------------
+
+- Fixed demotypes registration on modern Plone (Default alias was not working)
+  [keul]
+
 1.9.1 (2014-10-14)
 ------------------
 

--- a/Products/DataGridField/DataGridField.py
+++ b/Products/DataGridField/DataGridField.py
@@ -390,6 +390,12 @@ class DataGridField(ObjectField):
             # fixed rows behavior is disabled
             return data
 
+    security.declarePrivate('validate_required')
+    def validate_required(self, instance, value, errors):
+        value = value or []
+        value = [d for d in value if d.get('orderindex_', '').isdigit()]
+        return ObjectField.validate_required(self, instance, value, errors)
+
 
 class FixedRow:
     """ Row which is always present at DataGridField data.

--- a/Products/DataGridField/examples/DataGridDemoType.py
+++ b/Products/DataGridField/examples/DataGridDemoType.py
@@ -48,6 +48,7 @@ class DataGridDemoType(atapi.BaseContent):
 
         DataGridField('DemoField',
                 searchable=True, # One unit tests checks whether text search works
+                required=True,
                 widget = DataGridWidget(),
                 columns=('column1','column2','The third'),
                 default=[

--- a/Products/DataGridField/profiles/example/types/DataGridDemoType.xml
+++ b/Products/DataGridField/profiles/example/types/DataGridDemoType.xml
@@ -23,7 +23,7 @@
  <alias from="edit" to="base_edit"/>
  <alias from="index.html" to="(Default)"/>
  <alias from="properties" to="base_metadata"/>
- <alias from="view" to="(Default)"/>
+ <alias from="view" to="base_view"/>
  <action title="View" action_id="view" category="object" condition_expr="python:hasattr(object, '@@plone_lock_info') and object.restrictedTraverse('@@plone_lock_info').is_locked_for_current_user() or True"
     url_expr="string:${object_url}/view" visible="True">
   <permission value="View"/>

--- a/Products/DataGridField/profiles/example/types/DataGridDemoType2.xml
+++ b/Products/DataGridField/profiles/example/types/DataGridDemoType2.xml
@@ -26,7 +26,7 @@
  <alias from="edit" to="base_edit"/>
  <alias from="index.html" to="(Default)"/>
  <alias from="properties" to="base_metadata"/>
- <alias from="view" to="(Default)"/>
+ <alias from="view" to="base_view"/>
  <action title="View" action_id="view" category="object" condition_expr="python:hasattr(object, '@@plone_lock_info') and object.restrictedTraverse('@@plone_lock_info').is_locked_for_current_user() or True"
     url_expr="string:${object_url}/view" visible="True">
   <permission value="View"/>

--- a/Products/DataGridField/profiles/example/types/FixedRowsDemoType.xml
+++ b/Products/DataGridField/profiles/example/types/FixedRowsDemoType.xml
@@ -22,7 +22,7 @@
  <alias from="edit" to="base_edit"/>
  <alias from="index.html" to="(Default)"/>
  <alias from="properties" to="base_metadata"/>
- <alias from="view" to="(Default)"/>
+ <alias from="view" to="base_view"/>
  <action title="View" action_id="view" category="object" condition_expr="python:hasattr(object, '@@plone_lock_info') and object.restrictedTraverse('@@plone_lock_info').is_locked_for_current_user() or True"
     url_expr="string:${object_url}/view" visible="True">
   <permission value="View"/>

--- a/Products/DataGridField/profiles/example/types/InvalidDataGridDemoType.xml
+++ b/Products/DataGridField/profiles/example/types/InvalidDataGridDemoType.xml
@@ -24,7 +24,7 @@
  <alias from="edit" to="base_edit"/>
  <alias from="index.html" to="(Default)"/>
  <alias from="properties" to="base_metadata"/>
- <alias from="view" to="(Default)"/>
+ <alias from="view" to="base_view"/>
  <action title="View" action_id="view" category="object" condition_expr="python:hasattr(object, '@@plone_lock_info') and object.restrictedTraverse('@@plone_lock_info').is_locked_for_current_user() or True"
     url_expr="string:${object_url}/view" visible="True">
   <permission value="View"/>

--- a/Products/DataGridField/tests/test_data_manipulation.py
+++ b/Products/DataGridField/tests/test_data_manipulation.py
@@ -77,7 +77,9 @@ class TestInstallation(DataGridTestCase):
 
         obj = self.folder.foo
         field = obj.Schema()['DemoField']
-        self.assertEqual(field.validate_required(obj, (raw_data,), {}), None)
+        errors = {}
+        self.assertEqual(field.validate_required(obj, (raw_data,), errors), None)
+        self.assertEqual(errors, {})
 
     def testSettingEmptyTable(self):
         """ It should not be possible to set no rows at all when field is required """
@@ -91,7 +93,12 @@ class TestInstallation(DataGridTestCase):
 
         obj = self.folder.foo
         field = obj.Schema()['DemoField']
-        self.assertEqual(str(field.validate_required(obj, (raw_data,), {})),
+        errors = {}
+        self.assertEqual(str(field.validate_required(obj, (raw_data,), errors)),
+                         'DemoField is required, please correct.')
+        self.assertTrue(errors)
+        self.assertTrue('DemoField' in errors)
+        self.assertEqual(errors['DemoField'],
                          'DemoField is required, please correct.')
 
     def testRenderingDoesNotFail(self):

--- a/Products/DataGridField/tests/test_data_manipulation.py
+++ b/Products/DataGridField/tests/test_data_manipulation.py
@@ -63,13 +63,36 @@ class TestInstallation(DataGridTestCase):
         """ It should be possible to set empty rows """
         self.folder.invokeFactory('DataGridDemoType', 'foo')
 
-        vals = ({'The third': '', 'column1': 'xxx', 'column2': '', }, )
-        self.folder.foo.setDemoField(vals)
-        self.assertEqual(self.folder.foo.getDemoField(), vals)
+        data = {'The third': '', 'column1': 'xxx', 'column2': ''}
+        raw_data = data.copy()
+        raw_data['orderindex_'] = '1'
+        self.folder.foo.setDemoField((raw_data,))
+        self.assertEqual(self.folder.foo.getDemoField(), (data,))
 
-        vals = ({'The third': '', 'column1': '', 'column2': '', },)
-        self.folder.foo.setDemoField(vals)
-        self.assertEqual(self.folder.foo.getDemoField(), vals)
+        data = {'The third': '', 'column1': '', 'column2': ''}
+        raw_data = data.copy()
+        raw_data['orderindex_'] = '1'
+        self.folder.foo.setDemoField((raw_data,))
+        self.assertEqual(self.folder.foo.getDemoField(), (data,))
+
+        obj = self.folder.foo
+        field = obj.Schema()['DemoField']
+        self.assertEqual(field.validate_required(obj, (raw_data,), {}), None)
+
+    def testSettingEmptyTable(self):
+        """ It should not be possible to set no rows at all when field is required """
+        self.folder.invokeFactory('DataGridDemoType', 'foo')
+
+        data = {'The third': '', 'column1': '', 'column2': ''}
+        raw_data = data.copy()
+        raw_data['orderindex_'] = 'template_row_marker' # whatever is not a position digit
+        self.folder.foo.setDemoField((raw_data,))
+        self.assertEqual(self.folder.foo.getDemoField(), tuple())
+
+        obj = self.folder.foo
+        field = obj.Schema()['DemoField']
+        self.assertEqual(str(field.validate_required(obj, (raw_data,), {})),
+                         'DemoField is required, please correct.')
 
     def testRenderingDoesNotFail(self):
         """See if a page containing DGF will output HTML without

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.9.1'
+version = '1.9.2.dev0'
 readme = open("README.rst").read()
 history = open("CHANGES.rst").read()
 long_description = readme + "\n" + history


### PR DESCRIPTION
Right now the Archetypes ``required`` attribute for the field is only a visual element and not really working.

This is a know behavior fixed on version 1.6b3 by @mauritsvanrees (I think...) introducing the ``isDataGridFilled`` validator. I can't know why this has been done in that way (the Plone code is changed a lot) but my tests with changes in this pull request seems to fix the issue in a more natural way.

So:

* if the field is required you can't have empty DataGridField
* if the field is required you *can* have non empty DataGridField filled with empty rows
* requirements for non empty rows must be left to ``required`` column's attribute (introduced recently)
