### PR TITLE
Make sure validate_required validates stored data correctly, indeed the 'orderindex_' key is missing when data is stored.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,9 @@ Changelog
 1.9.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Make sure validate_required validates stored data correctly,
+  indeed the 'orderindex_' key is missing when data is stored.
+  [gbastien]
 
 1.9.2 (2015-08-31)
 ------------------

--- a/Products/DataGridField/DataGridField.py
+++ b/Products/DataGridField/DataGridField.py
@@ -393,7 +393,7 @@ class DataGridField(ObjectField):
     security.declarePrivate('validate_required')
     def validate_required(self, instance, value, errors):
         value = value or []
-        value = [d for d in value if d.get('orderindex_', '').isdigit()]
+        value = [d for d in value if d.get('orderindex_', '1').isdigit()]
         return ObjectField.validate_required(self, instance, value, errors)
 
 

--- a/Products/DataGridField/tests/test_data_manipulation.py
+++ b/Products/DataGridField/tests/test_data_manipulation.py
@@ -50,8 +50,8 @@ class TestInstallation(DataGridTestCase):
 
     def testSettingFieldWithOrder(self):
         self.folder.invokeFactory('DataGridDemoType', 'foo')
-        vals = [{'column1':'joe', 'orderindex_': 1},
-                {'column1':'jack', 'orderindex_': 0}]
+        vals = [{'column1': 'joe', 'orderindex_': 1},
+                {'column1': 'jack', 'orderindex_': 0}]
         self.folder.foo.setDemoField(vals)
         self.assertEqual(len(self.folder.foo.getDemoField()), 2)
         self.assertEqual(self.folder.foo.getDemoField()[0]['column1'],
@@ -81,13 +81,18 @@ class TestInstallation(DataGridTestCase):
         self.assertEqual(field.validate_required(obj, (raw_data,), errors), None)
         self.assertEqual(errors, {})
 
+        # validate_required stored data, it will miss the 'orderindex_' key
+        del raw_data['orderindex_']
+        self.assertEqual(field.validate_required(obj, (raw_data,), errors), None)
+        self.assertEqual(errors, {})
+
     def testSettingEmptyTable(self):
         """ It should not be possible to set no rows at all when field is required """
         self.folder.invokeFactory('DataGridDemoType', 'foo')
 
         data = {'The third': '', 'column1': '', 'column2': ''}
         raw_data = data.copy()
-        raw_data['orderindex_'] = 'template_row_marker' # whatever is not a position digit
+        raw_data['orderindex_'] = 'template_row_marker'  # whatever is not a position digit
         self.folder.foo.setDemoField((raw_data,))
         self.assertEqual(self.folder.foo.getDemoField(), tuple())
 


### PR DESCRIPTION
Hi @mauritsvanrees @keul,

recent changes regarding required_validate breaks my content_type because the stored data does not have the 'orderindex_' key, it is the case when using multi-tabs forms for example.

Could you please review/comment/merge this PR?

Thank you!

Gauthier