### PR TITLE
Take default value of CheckboxColumn into account while adding a new column in the edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.9.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Take default value of CheckboxColumn into account while adding
+  a new column in the edit form.
+  [gbastien]
 
 
 1.9.3 (2015-09-07)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Take default value of CheckboxColumn into account while adding
-  a new column in the edit form.
+  a new row in the edit form.
   [gbastien]
 
 

--- a/Products/DataGridField/skins/DataGridWidget/datagrid_checkbox_cell.pt
+++ b/Products/DataGridField/skins/DataGridWidget/datagrid_checkbox_cell.pt
@@ -33,7 +33,8 @@
            <input class="noborder"
                   type="checkbox"
                   value="1"
-                  tal:attributes="name string:${fieldName}.${column}.999999;
+                  tal:attributes="checked python: column_definition.getDefault(here) == '1';
+                                  name string:${fieldName}.${column}.999999;
                                   title column_label;"
                 />
         </tal:block>
@@ -42,4 +43,3 @@
 </body>
 
 </html>
-


### PR DESCRIPTION
Hi @mauritsvanrees 

sorry I forgot to push this change together with previous one...

Can you have a look when you have time?  It will "check" the box depending on CheckboxColumn default while adding a new row...

If you are about to add some other feature, we can wait for a release to avoid several releases same day ;-)

Thank you!

Gauthier