### PR TITLE
Make it possible to show a hidden column in "view" mode using CSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,11 @@ Changelog
 1.9.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- While hidding a column it is hidden in both view/edit mode without
+  distinction. In "view" mode, while generating the used class
+  'dgw-hidden-column', append the column id so it is possible, like
+  in "edit" mode to use a CSS selector to show a hidden column.
+  [gbastien]
 
 
 1.9.4 (2015-09-07)

--- a/Products/DataGridField/skins/DataGridWidget/datagridwidget.pt
+++ b/Products/DataGridField/skins/DataGridWidget/datagridwidget.pt
@@ -13,7 +13,7 @@
             <thead tal:condition="python: widget.hasHeader(context, field)">
                 <tr>
                     <tal:block tal:repeat="c columns"
-                      ><th tal:attributes="class python:not c['visible'] and 'dgw-hidden-column' or '';"
+                      ><th tal:attributes="class python:not c['visible'] and 'dgw-hidden-column %s' % c['id'] or '';"
                         tal:content="c/label" i18n:translate="">NAME</th
                     ></tal:block>
                 </tr>

--- a/Products/DataGridField/skins/DataGridWidget/datagridwidget_view_row.pt
+++ b/Products/DataGridField/skins/DataGridWidget/datagridwidget_view_row.pt
@@ -23,7 +23,7 @@
 		     tal:attributes="class python:field.allow_oddeven and (oddrow and 'odd' or 'even') or nothing;">
 		   <tal:block tal:repeat="columnd columns">
              <td tal:define="col_cls string:col-${repeat/columnd/number}"
-                 tal:attributes="class python:not columnd['visible'] and 'dgw-hidden-column %s' or col_cls;">
+                 tal:attributes="class python:not columnd['visible'] and 'dgw-hidden-column %s' % columnd['id'] or col_cls;">
 
 		         <span tal:define="
 				       column columnd/id;


### PR DESCRIPTION
While hidding a column it is hidden in both view/edit mode without distinction. In "view" mode, while generating the used class 'dgw-hidden-column', append the column id so it is possible, like in "edit" mode to use a CSS selector to show a hidden column.