### PR TITLE
Fixed error when used as widget in PloneFormGen 1.7.19 or higher.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 1.9.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed error when used as widget in PloneFormGen 1.7.19 or higher.
+  The widget has no ``REQUEST`` attribute there, because it is not
+  acquisition wrapped.  [maurits]
 
 
 1.9.5 (2016-03-22)

--- a/Products/DataGridField/DataGridWidget.py
+++ b/Products/DataGridField/DataGridWidget.py
@@ -109,7 +109,7 @@ class DataGridWidget(TypesWidget):
             item = {'id':id, 'label':'', 'visible':True}
             visible = getattr(c, 'visible', True)
             item['visible'] = visible
-            item['label'] = c.getLabel(instance, self.REQUEST)
+            item['label'] = c.getLabel(instance, instance.REQUEST)
             item['required'] = getattr(c, 'required', False)
             item['col_description'] = getattr(c, 'col_description', '')
             result.append(item)


### PR DESCRIPTION
The widget has no ``REQUEST`` attribute there, because it is not acquisition wrapped.